### PR TITLE
Improved description for the conn_handler argument in addSignature() …

### DIFF
--- a/R/addSignature.R
+++ b/R/addSignature.R
@@ -1,7 +1,8 @@
 #' @title addSignature
 #' @description Add signature to database
-#' @param conn_handler A handler uses to establish connection to the database 
-#' obtained from SigRepo::newConnhandler() (required)
+#' @param conn_handler A connection handler object obtained from a call to 
+#' SigRepo::newConnhandler() to establish a connection with 
+#' the database. \strong{Required}
 #' @param omic_signature An R6 class object from OmicSignature package (required)
 #' @param visibility A logical value indicates whether or not to allow others  
 #' to view and access one's uploaded signature. Default is \code{FALSE}.

--- a/man/addSignature.Rd
+++ b/man/addSignature.Rd
@@ -15,8 +15,9 @@ addSignature(
 )
 }
 \arguments{
-\item{conn_handler}{A handler uses to establish connection to the database 
-obtained from SigRepo::newConnhandler() (required)}
+\item{conn_handler}{A connection handler object obtained from a call to 
+SigRepo::newConnhandler() to establish a connection with 
+the database. \strong{Required}}
 
 \item{omic_signature}{An R6 class object from OmicSignature package (required)}
 


### PR DESCRIPTION
## Fix description
the current description of the `conn_handler` argument in the `addSignature()` function is not clear.  This pull request makes an attempt to make it better.


