### PR TITLE
Add user-firendly error message when a wrong connection handler is used

### DIFF
--- a/R/addSignature.R
+++ b/R/addSignature.R
@@ -46,7 +46,14 @@ addSignature <- function(
   SigRepo::print_messages(verbose = verbose)
   
   # Establish user connection ###
-  conn <- SigRepo::conn_init(conn_handler = conn_handler)
+  # Assert that the following function executes without error and
+  # give an error message if it fails
+  tryCatch({
+    conn <- SigRepo::conn_init(conn_handler = conn_handler)
+  }, error = function(e){
+    base::stop("Cannot connect to the database. Please check your connection handler.")
+  })
+  
   
   # Check user connection and permission ####
   conn_info <- SigRepo::checkPermissions(

--- a/tests/testthat/test_signatures.R
+++ b/tests/testthat/test_signatures.R
@@ -24,8 +24,20 @@ test_that("addSignature correctly adds a transcriptomic signature into the datab
   # Create signature object 
   test_transcriptomics_sig <- base::readRDS(testthat::test_path("test_data", "test_data_transcriptomics.rds"))
 
-  # calling the function to add the test signature into the database ####
+  # Ensure a proper error message is displayed when using a wrong 
+  # connection handler
+  wrong_connection_handler <- -1
+  expect_error( 
+    
+    error_id <- SigRepo::addSignature(
+    conn_handler = wrong_connection_handler,
+    omic_signature = test_transcriptomics_sig,
+    return_signature_id = TRUE,
+    verbose = FALSE
+  ),"Cannot connect to the database. Please check your connection handler.")
   
+  
+  # calling the function to add the test signature into the database ####
   # using <<- to add the id globally so the tests can use it ####
   transcriptomics_signature_id <<- SigRepo::addSignature(
     conn_handler = test_conn,


### PR DESCRIPTION
1. Add user-friendly error message when a wrong connection handler is used
2. Add corresponding unit test