### PR TITLE
Fixes issue #117: Handling invalid connection when calling searchOrganism() function

### DIFF
--- a/R/searchOrganism.R
+++ b/R/searchOrganism.R
@@ -24,7 +24,13 @@ searchOrganism <- function(
   SigRepo::print_messages(verbose = verbose)
 
   # Establish user connection ###
-  conn <- SigRepo::conn_init(conn_handler = conn_handler)
+  tryCatch({
+    conn <- SigRepo::conn_init(conn_handler = conn_handler)
+
+  },  error = function(e){
+    stop("Failed to connect to the SigRepo Database. Invalid connection.", call. = FALSE)
+  }
+  )
   
   # Check user connection and permissions ####
   conn_info <- SigRepo::checkPermissions(

--- a/tests/testthat/test_Organisms.R
+++ b/tests/testthat/test_Organisms.R
@@ -61,11 +61,8 @@ test_that("searchOrganism handles invalid connection gracefully", {
   # Expect error or empty result when connection fails
   expect_error(
     SigRepo::searchOrganism(conn_handler = invalid_conn),
-    regexp = ".*"  # Any error message
+    regexp = "Invalid connection"  # Any error message
   )
-  # Katia: search Organism() function needs to be fixed to handle invalid host
-  # It should return an informative error 
-  ##expect_true(nrow(SigRepo::searchOrganism(conn_handler = invalid_conn)) == 0)
 })
 
 test_that("searchOrganism handles NULL connection handler", {


### PR DESCRIPTION
Handle invalid connection when calling searchOrganism() function:
use `tryCatch()` function to handle invalid connection input.