### PR TITLE
PR addess test bugs related to deleting signatures, as well as expect…

### DIFF
--- a/tests/testthat/test_Organisms.R
+++ b/tests/testthat/test_Organisms.R
@@ -61,7 +61,7 @@ test_that("searchOrganism handles invalid connection gracefully", {
   # Expect error or empty result when connection fails
   expect_error(
     SigRepo::searchOrganism(conn_handler = invalid_conn),
-    regexp = "Invalid connection"  # Any error message
+    regexp = "Please check your host, username, password, and network connection."  # Any error message
   )
 })
 

--- a/tests/testthat/test_collections.R
+++ b/tests/testthat/test_collections.R
@@ -32,11 +32,20 @@ test_that("addCollection correctly adds a signature into the database", {
       verbose = TRUE
     )
     
+    
+    expect_no_error({
+      id_1 <- searchSignature(conn_handler = test_conn,
+                              signature_name = "sig_for_collection_1")$signature_id
+      id_2 <- searchSignature(conn_handler = test_conn, 
+                              signature_name = "sig_for_collection_2" )$signature_id
+    })
+    
+    
     # remove signatures
     expect_no_error({
       SigRepo::deleteSignature(
         conn_handler = test_conn,
-        signature_name = "sig_for_collection_1",
+        signature_id = id_1,
         verbose = TRUE
       )
     })
@@ -44,7 +53,7 @@ test_that("addCollection correctly adds a signature into the database", {
     expect_no_error({
       SigRepo::deleteSignature(
         conn_handler = test_conn,
-        signature_name = "sig_for_collection_2",
+        signature_id = id_2,
         verbose = TRUE
       )
     })
@@ -89,20 +98,28 @@ test_that("searchSignature correctly searches for the desired signature",{
     )
   })
   
+  expect_no_error({
+    id_1 <- searchSignature(conn_handler = test_conn,
+                            signature_name = "sig_for_collection_1")$signature_id
+    id_2 <- searchSignature(conn_handler = test_conn, 
+                            signature_name = "sig_for_collection_2" )$signature_id
+  })
+  
+  
   # remove signatures
   expect_no_error({
     SigRepo::deleteSignature(
       conn_handler = test_conn,
-      signature_name = "sig_for_collection_1",
-      verbose = FALSE
+      signature_id = id_1,
+      verbose = TRUE
     )
   })
   
   expect_no_error({
     SigRepo::deleteSignature(
       conn_handler = test_conn,
-      signature_name = "sig_for_collection_2",
-      verbose = FALSE
+      signature_id = id_2,
+      verbose = TRUE
     )
   })
 })

--- a/tests/testthat/test_signatures.R
+++ b/tests/testthat/test_signatures.R
@@ -161,15 +161,18 @@ test_that("addSignature handles duplicate signatures", {
   
   # Try to add same signature again
 
-  expect_error({
+  expect_message(
     SigRepo::addSignature(
       conn_handler = test_conn,
       omic_signature = test_transcriptomics_sig,
       return_signature_id = TRUE,
-      verbose = FALSE
-    )
-  }) 
-
+      verbose = TRUE
+    ),
+    regexp = "You already uploaded a signature with the name = 'test_signature'"
+  )
+  
+  
+  
 
   
   # remove signature


### PR DESCRIPTION
PR addresses issue #136 where some tests were failing because of incorrect deleteSignature usage, also fixed organisms tests where the expected message was incorrect.