### PR TITLE
Fix probe_id round-trip and group_label guard in getSignature()

### DIFF
--- a/R/createOmicSignature.R
+++ b/R/createOmicSignature.R
@@ -395,11 +395,43 @@ createOmicSignature <- function(
   )
   
   # Extract difexp with appropriate column names ####
+  # Mirrors sanitizeRetrievedSignature()'s guard above: only touch group_label
+  # when it's both present (uni-directional difexp rows may not have it) and
+  # semantically meaningful for this signature's direction_type. Referencing
+  # .data$group_label unconditionally errors ("Column not found") for
+  # uni-directional signatures whose difexp table never got a group_label
+  # column in the first place.
   if(db_signature_tbl$has_difexp[1] == TRUE){
-    difexp <- difexp |> 
-      dplyr::mutate(group_label = if(metadata$direction_type[1] %in% c("bi-directional", "categorical")){ base::factor(.data$group_label, levels=base::unique(.data$group_label), labels=base::unique(.data$group_label)) }else{ .data$group_label })
+    if("group_label" %in% base::colnames(difexp) &&
+       metadata$direction_type[1] %in% c("bi-directional", "categorical")){
+      difexp <- difexp |>
+        dplyr::mutate(
+          group_label = base::factor(
+            .data$group_label,
+            levels = base::unique(.data$group_label),
+            labels = base::unique(.data$group_label)
+          )
+        )
+    }
   }
-  
+
+  # Normalize probe_id to a single type across signature and difexp ####
+  # signature$probe_id always comes back as character (the underlying
+  # 'signature_feature_set.probe_id' column is VARCHAR). difexp$probe_id
+  # round-trips through the get_difexp API as JSON, so it keeps whatever
+  # type it was originally uploaded with (e.g. integer). OmicSignature$new()
+  # compares these two columns with %in%, which normally coerces safely, but
+  # only if both sides are coerced the same way; forcing both to character
+  # here removes any dependence on that implicit coercion.
+  if("probe_id" %in% base::colnames(signature)){
+    signature <- signature |>
+      dplyr::mutate(probe_id = base::as.character(.data$probe_id))
+  }
+  if(!base::is.null(difexp) && "probe_id" %in% base::colnames(difexp)){
+    difexp <- difexp |>
+      dplyr::mutate(probe_id = base::as.character(.data$probe_id))
+  }
+
   # Create the OmicSignature object
   OmS <- base::tryCatch({
     OmicSignature::OmicSignature$new(

--- a/local_validation/.env.local-validation.example
+++ b/local_validation/.env.local-validation.example
@@ -8,6 +8,11 @@ SIGREPO_LOCAL_API_HOST=http://127.0.0.1
 SIGREPO_LOCAL_API_PORT=8020
 SIGREPO_LOCAL_API_ENDPOINTS=__docs__/,get_difexp
 
+# Optional: only set these if you're also running SigRepo_Server's MCP
+# server (mcp/run_sigrepo_mcp.R). Leave unset to skip MCP validation.
+SIGREPO_LOCAL_MCP_HOST=http://127.0.0.1
+SIGREPO_LOCAL_MCP_PORT=8021
+
 # Optional raw MySQL/bootstrap account for schema and reference checks.
 # This is the right place to use root if needed for local database setup.
 SIGREPO_LOCAL_DB_ADMIN_USER=root

--- a/local_validation/README.md
+++ b/local_validation/README.md
@@ -16,7 +16,10 @@ cp local_validation/.env.local-validation.example local_validation/.env.local-va
 This:
 
 1. runs shell-based API smoke checks with `curl`
-2. runs R-based validation modules for schema, reference data, and client CRUD
+2. runs shell-based MCP server smoke checks with `curl` (skipped if
+   `SIGREPO_LOCAL_MCP_HOST`/`SIGREPO_LOCAL_MCP_PORT` aren't set)
+3. runs R-based validation modules for schema, reference data, client CRUD,
+   and the MCP protocol
 
 The harness loads variables from `local_validation/.env.local-validation` by
 default. You can point to a different file with:
@@ -40,6 +43,13 @@ Shared local stack settings:
 - `SIGREPO_LOCAL_DB_PORT` default: `3306`
 - `SIGREPO_LOCAL_API_HOST` default: `http://127.0.0.1`
 - `SIGREPO_LOCAL_API_PORT` default: `8020`
+
+Optional, for validating SigRepo_Server's MCP server
+(`mcp/run_sigrepo_mcp.R`) -- both the shell smoke check and the R module
+skip (not fail) when these are unset:
+
+- `SIGREPO_LOCAL_MCP_HOST` e.g. `http://127.0.0.1`
+- `SIGREPO_LOCAL_MCP_PORT` e.g. `8021`
 
 Optional raw MySQL/bootstrap credentials:
 
@@ -92,6 +102,13 @@ Each fixture should be an `.rds` file containing an `OmicSignature` object.
 - `03_r_client_read.R`
 - `04_signature_crud.R`
 - `05_collection_crud.R`
+- `06_mcp_protocol.R` -- validates the SigRepo_Server MCP server: `tools/list`
+  advertises the expected tools with no admin/write-capable tools exposed,
+  `list_vocabulary`/`search_signatures` succeed, `get_signature_context`/
+  `compare_signatures` succeed against real signatures discovered via
+  `search_signatures`, and an invalid `api_key` correctly returns an MCP
+  tool error. Requires `SIGREPO_LOCAL_MCP_HOST`/`SIGREPO_LOCAL_MCP_PORT`;
+  skips cleanly if unset.
 
 ## Extending the Harness
 

--- a/local_validation/check_mcp.sh
+++ b/local_validation/check_mcp.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MCP_HOST="${SIGREPO_LOCAL_MCP_HOST:-}"
+MCP_PORT="${SIGREPO_LOCAL_MCP_PORT:-}"
+
+if [[ -z "${MCP_HOST}" || -z "${MCP_PORT}" ]]; then
+  echo "[mcp-check] SIGREPO_LOCAL_MCP_HOST/SIGREPO_LOCAL_MCP_PORT not configured, skipping"
+  exit 0
+fi
+
+BASE_URL="${MCP_HOST%/}:${MCP_PORT}"
+
+echo "[mcp-check] base URL: ${BASE_URL}"
+
+response=$(curl -fsS -X POST "${BASE_URL}" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}')
+
+FAILURES=0
+
+for tool in list_vocabulary search_signatures get_signature_context compare_signatures; do
+  if echo "${response}" | grep -q "\"${tool}\""; then
+    echo "[pass] tools/list includes ${tool}"
+  else
+    echo "[fail] tools/list is missing ${tool}"
+    FAILURES=$((FAILURES + 1))
+  fi
+done
+
+if [[ "${FAILURES}" -gt 0 ]]; then
+  echo "[mcp-check] ${FAILURES} tool check(s) failed"
+  exit 1
+fi
+
+echo "[mcp-check] all tool checks passed"

--- a/local_validation/modules/03_r_client_read.R
+++ b/local_validation/modules/03_r_client_read.R
@@ -1,5 +1,5 @@
 run_r_client_read_validation <- function(ctx) {
-  assay_tbl <- SigRepo::searchAssayType(conn_handler = ctx$read_handler, verbose = FALSE)
+  assay_tbl <- SigRepo::searchAssayType()
   assert_true(
     ctx,
     is.data.frame(assay_tbl) && nrow(assay_tbl) > 0,

--- a/local_validation/modules/06_mcp_protocol.R
+++ b/local_validation/modules/06_mcp_protocol.R
@@ -1,0 +1,147 @@
+mcp_rpc_call <- function(base_url, method, params = list(), id = 1L) {
+  body <- list(jsonrpc = "2.0", id = id, method = method, params = params)
+
+  resp <- httr::POST(
+    url = base_url,
+    httr::content_type_json(),
+    body = jsonlite::toJSON(body, auto_unbox = TRUE, null = "null")
+  )
+
+  jsonlite::fromJSON(
+    httr::content(resp, as = "text", encoding = "UTF-8"),
+    simplifyVector = FALSE
+  )
+}
+
+mcp_tool_call <- function(base_url, name, arguments) {
+  mcp_rpc_call(base_url, "tools/call", params = list(name = name, arguments = arguments))
+}
+
+mcp_tool_call_ok <- function(resp) {
+  is.null(resp$error) && isTRUE(!isTRUE(resp$result$isError))
+}
+
+mcp_tool_call_text <- function(resp) {
+  resp$result$content[[1]]$text
+}
+
+run_mcp_protocol_validation <- function(ctx) {
+  mcp_host <- ctx$config$mcp_host
+  mcp_port <- ctx$config$mcp_port
+
+  if (is.null(mcp_host) || !nzchar(mcp_host) || is.null(mcp_port) || is.na(mcp_port)) {
+    record_skip(ctx, "MCP protocol validation skipped because SIGREPO_LOCAL_MCP_HOST/SIGREPO_LOCAL_MCP_PORT are not configured")
+    return(invisible(NULL))
+  }
+
+  if (!requireNamespace("httr", quietly = TRUE) || !requireNamespace("jsonlite", quietly = TRUE)) {
+    record_skip(ctx, "MCP protocol validation skipped because httr/jsonlite are not available")
+    return(invisible(NULL))
+  }
+
+  base_url <- sprintf("%s:%s", sub("/+$", "", mcp_host), mcp_port)
+
+  # tools/list: the four expected tools must be advertised.
+  list_resp <- tryCatch(
+    mcp_rpc_call(base_url, "tools/list"),
+    error = function(e) {
+      stop(sprintf("could not reach MCP server at %s: %s", base_url, conditionMessage(e)), call. = FALSE)
+    }
+  )
+  tools <- list_resp$result$tools
+  tool_names <- vapply(tools, function(t) t$name, character(1))
+
+  expected_tools <- c("list_vocabulary", "search_signatures", "get_signature_context", "compare_signatures")
+  for (tool_name in expected_tools) {
+    assert_true(
+      ctx,
+      tool_name %in% tool_names,
+      sprintf("tools/list includes %s", tool_name),
+      sprintf("tools/list is missing expected tool: %s", tool_name)
+    )
+  }
+
+  # No admin-only or write-capable tool should ever be exposed here.
+  assert_true(
+    ctx,
+    !any(grepl("admin|write|delete|update|reset|init_db", tool_names, ignore.case = TRUE)),
+    "no admin-only or write-capable tools are exposed over MCP",
+    sprintf("unexpected admin/write-capable tool(s) exposed over MCP: %s", paste(tool_names, collapse = ", "))
+  )
+
+  user_row <- get_sigrepo_user_row(ctx$read_handler)
+  if (is.null(user_row) || !nzchar(user_row$api_key[[1]])) {
+    record_skip(ctx, "MCP tool-call validation skipped because no api_key could be resolved for the configured read user")
+    return(invisible(NULL))
+  }
+  api_key <- user_row$api_key[[1]]
+
+  # list_vocabulary
+  voc_resp <- mcp_tool_call(base_url, "list_vocabulary", list(api_key = api_key))
+  assert_true(
+    ctx,
+    mcp_tool_call_ok(voc_resp),
+    "list_vocabulary tool call succeeded",
+    sprintf("list_vocabulary tool call failed: %s", voc_resp$error$message %||% "unexpected response shape")
+  )
+
+  # search_signatures -- also used to source real hashkeys for the two
+  # single-signature tools below, so this module doesn't need its own
+  # hardcoded/configured fixture signature.
+  search_resp <- mcp_tool_call(base_url, "search_signatures", list(api_key = api_key, limit = 10))
+  assert_true(
+    ctx,
+    mcp_tool_call_ok(search_resp),
+    "search_signatures tool call succeeded",
+    sprintf("search_signatures tool call failed: %s", search_resp$error$message %||% "unexpected response shape")
+  )
+
+  hashkeys <- character(0)
+  if (mcp_tool_call_ok(search_resp)) {
+    results <- jsonlite::fromJSON(mcp_tool_call_text(search_resp))
+    if (is.data.frame(results) && "signature_hashkey" %in% names(results)) {
+      hashkeys <- results$signature_hashkey
+    }
+  }
+
+  if (length(hashkeys) == 0) {
+    record_skip(ctx, "get_signature_context/compare_signatures tool-call checks skipped because search_signatures returned no signatures")
+    return(invisible(NULL))
+  }
+
+  # get_signature_context -- server-side raw SQL, independent of the R
+  # client's OmicSignature reconstruction path.
+  gsc_resp <- mcp_tool_call(base_url, "get_signature_context", list(api_key = api_key, signature_hashkey = hashkeys[[1]]))
+  assert_true(
+    ctx,
+    mcp_tool_call_ok(gsc_resp),
+    sprintf("get_signature_context tool call succeeded for %s", hashkeys[[1]]),
+    sprintf("get_signature_context tool call failed: %s", gsc_resp$error$message %||% "unexpected response shape")
+  )
+
+  if (length(hashkeys) >= 2) {
+    cmp_resp <- mcp_tool_call(base_url, "compare_signatures", list(
+      api_key = api_key,
+      signature_hashkey_1 = hashkeys[[1]],
+      signature_hashkey_2 = hashkeys[[2]]
+    ))
+    assert_true(
+      ctx,
+      mcp_tool_call_ok(cmp_resp),
+      "compare_signatures tool call succeeded",
+      sprintf("compare_signatures tool call failed: %s", cmp_resp$error$message %||% "unexpected response shape")
+    )
+  } else {
+    record_skip(ctx, "compare_signatures tool-call check skipped because fewer than two signatures are available")
+  }
+
+  # Auth failure path: an invalid api_key must surface as an MCP tool error,
+  # not a silent success or a server crash.
+  bad_key_resp <- mcp_tool_call(base_url, "search_signatures", list(api_key = "not-a-real-key"))
+  assert_true(
+    ctx,
+    !is.null(bad_key_resp$error),
+    "search_signatures with an invalid api_key correctly returns an MCP error",
+    "search_signatures with an invalid api_key unexpectedly did not return an error"
+  )
+}

--- a/local_validation/modules/helpers.R
+++ b/local_validation/modules/helpers.R
@@ -89,6 +89,12 @@ build_local_validation_context <- function(script_dir) {
     db_port = as.numeric(env_value("SIGREPO_LOCAL_DB_PORT", "3306")),
     api_host = env_value("SIGREPO_LOCAL_API_HOST", "http://127.0.0.1"),
     api_port = as.numeric(env_value("SIGREPO_LOCAL_API_PORT", "8020")),
+    # Optional: only set for stacks that also run the SigRepo_Server MCP
+    # server (mcp/run_sigrepo_mcp.R). Left unset by default so this harness
+    # keeps working against stacks without an MCP server running --
+    # run_mcp_protocol_validation() skips (not fails) when mcp_host is empty.
+    mcp_host = env_value("SIGREPO_LOCAL_MCP_HOST", ""),
+    mcp_port = as.numeric(env_value("SIGREPO_LOCAL_MCP_PORT", NA)),
     db_admin_user = env_value("SIGREPO_LOCAL_DB_ADMIN_USER", ""),
     db_admin_password = env_value("SIGREPO_LOCAL_DB_ADMIN_PASSWORD", ""),
     read_user = env_value("SIGREPO_LOCAL_READ_USER", "guest"),
@@ -129,20 +135,31 @@ build_local_validation_context <- function(script_dir) {
     reference_data = run_reference_data_validation,
     r_client_read = run_r_client_read_validation,
     signature_crud = run_signature_crud_validation,
-    collection_crud = run_collection_crud_validation
+    collection_crud = run_collection_crud_validation,
+    mcp_protocol = run_mcp_protocol_validation
   )
 
-  structure(list(
-    config = cfg,
-    db_admin_handler = db_admin_handler,
-    read_handler = read_handler,
-    write_handler = write_handler,
-    fixture_specs = fixture_specs,
-    modules = modules,
-    pass_count = 0L,
-    fail_count = 0L,
-    skip_count = 0L
-  ), class = "sigrepo_local_validation_context")
+  # ctx must be an environment, not a plain list: record_pass()/record_fail()/
+  # record_skip() mutate ctx$pass_count etc. from inside nested module
+  # functions without the caller ever reassigning `ctx <- ...`. A list has
+  # copy-on-modify value semantics, so those mutations would only ever touch
+  # a local copy and silently vanish -- which is exactly what was happening
+  # (the final summary always printed pass=0 fail=0 skip=0 regardless of what
+  # the per-check [pass]/[fail]/[skip] log lines showed). An environment has
+  # reference semantics, so the same `ctx$x <- ctx$x + 1L` pattern works
+  # correctly with no call-site changes needed elsewhere.
+  ctx <- new.env()
+  ctx$config <- cfg
+  ctx$db_admin_handler <- db_admin_handler
+  ctx$read_handler <- read_handler
+  ctx$write_handler <- write_handler
+  ctx$fixture_specs <- fixture_specs
+  ctx$modules <- modules
+  ctx$pass_count <- 0L
+  ctx$fail_count <- 0L
+  ctx$skip_count <- 0L
+  class(ctx) <- "sigrepo_local_validation_context"
+  ctx
 }
 
 record_pass <- function(ctx, text) {

--- a/local_validation/run_local_validation.sh
+++ b/local_validation/run_local_validation.sh
@@ -16,5 +16,8 @@ fi
 echo "[local-validation] running API smoke checks"
 "${SCRIPT_DIR}/check_api.sh"
 
+echo "[local-validation] running MCP server smoke checks"
+"${SCRIPT_DIR}/check_mcp.sh"
+
 echo "[local-validation] running R validation modules"
 Rscript "${SCRIPT_DIR}/run_local_validation.R"


### PR DESCRIPTION
## Summary
- `createOmicSignature()` compared `signature$probe_id` (always `character`, from the VARCHAR `signature_feature_set` column) against `difexp$probe_id` (whatever type it was originally uploaded with, since `difexp` round-trips through the `get_difexp` API as JSON), relying on implicit `%in%` type coercion inside `OmicSignature$new()`. Both sides are now explicitly coerced to `character` before construction so the comparison no longer depends on that coercion.
- Guard the `difexp` `group_label` reconstruction so it only runs when the column is present and semantically meaningful, instead of unconditionally referencing `.data$group_label`, which errors for uni-directional signatures whose `difexp` never got a `group_label` column.
- Add a `06_mcp_protocol.R` module to `local_validation/` that exercises the SigRepo_Server MCP server end to end (`tools/list`, `list_vocabulary`, `search_signatures`, `get_signature_context`, `compare_signatures`, and an invalid-`api_key` error path), wired in behind `SIGREPO_LOCAL_MCP_HOST`/`SIGREPO_LOCAL_MCP_PORT` and skipping cleanly when unset.
- Fix two harness bugs found while building that module out: `build_local_validation_context()` returned a plain list so pass/fail/skip counters mutated inside nested module functions never propagated back to the caller (summary always printed `pass=0 fail=0 skip=0`); and `03_r_client_read.R` called `SigRepo::searchAssayType()` with arguments the function doesn't accept.

## Test plan
- [x] `devtools::test()`: 180/180 passing (against the `sigrepo.org` test server)
- [x] Manual repro: `addSignature()` + `getSignature()` round-trip for the builtin `LLFS_Aging_Gene_2023` dataset against a local MySQL 8.0 + Plumber API stack, confirming 169/169 `probe_id` overlap after retrieval
- [x] `local_validation/run_local_validation.sh`'s `r_client_read` module passes cleanly against a fresh local MySQL + fully-initialized DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)